### PR TITLE
Fix so the Promise resolves true or false depending on timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ Subject.prototype.wait = function (timeout) {
   this.waiters.push(waiter);
   var promise = new Promise(function (resolve) {
     var resolved = false;
+    waiter.expired = false;
     waiter.resolve = function (noRemove) {
       if (resolved) {
         return;
@@ -23,12 +24,13 @@ Subject.prototype.wait = function (timeout) {
           self.waiters.splice(pos, 1);
         }
       }
-      resolve();
+      resolve(!waiter.expired);
     };
   });
   if (timeout > 0 && isFinite(timeout)) {
     waiter.timeout = setTimeout(function () {
       waiter.timeout = null;
+      waiter.expired = true;
       waiter.resolve();
     }, timeout);
   }


### PR DESCRIPTION
Fix for issue #1. Original documentation states that the wait promise resolves false if timeout occurs, resolves true otherwise. Prior to this fix the resolved promise returned undefined.